### PR TITLE
Upgrade recon_enum scripts from Python 2 to Python 3

### DIFF
--- a/recon_enum/dirbust.py
+++ b/recon_enum/dirbust.py
@@ -8,38 +8,36 @@ if len(sys.argv) != 5:
     print("Usage: dirbust.py <target url> <port> <scan name> <log directory>")
     sys.exit(0)
 
-url = str(sys.argv[1])
-port = str(sys.argv[2])
-name = str(sys.argv[3])
-log_dir = str(sys.argv[4])
-folders = ["/usr/share/dirb/wordlists", "/usr/share/dirb/wordlists/vulns"]
+url = sys.argv[1]
+port = sys.argv[2]
+name = sys.argv[3]
+log_dir = sys.argv[4]
+folders = ["/usr/share/dirb/wordlists", "/usr/share/dirb/wordlists/vulns",
+           "/usr/local/share/dirb/wordlists", "/usr/local/share/dirb/wordlists/vulns"]
 
-directory = "%s/%s/dirb/%s" % (log_dir, name, port)
-if not os.path.exists(directory):
-    os.makedirs(directory)
+directory = f"{log_dir}/{name}/dirb/{port}"
+os.makedirs(directory, exist_ok=True)
 
 found = []
-print("INFO: Starting dirb scan for " + url)
+print(f"INFO: Starting dirb scan for {url}")
 for folder in folders:
+    if not os.path.exists(folder):
+        continue
     for filename in os.listdir(folder):
-        outfile = "-o %s/%s/dirb/%s/%s_dirb_%s" % (log_dir, name, port, name, filename)
-        #outfile = " -o " + "results/exam/" + name + "_dirb_" + filename
-        DIRBSCAN = "dirb %s:%s %s/%s %s -S -r" % (url, port, folder, filename, outfile)
-        print(DIRBSCAN)
+        outfile = f"-o {log_dir}/{name}/dirb/{port}/{name}_dirb_{filename}"
+        cmd = f"dirb {url}:{port} {folder}/{filename} {outfile} -S -r"
+        print(cmd)
         try:
-            results = subprocess.check_output(DIRBSCAN, shell=True).decode('utf-8')
-            resultarr = results.split("\n")
-            for line in resultarr:
-                if "+" in line:
-                    if line not in found:
-                        found.append(line)
-        except:
+            results = subprocess.run(cmd, shell=True, capture_output=True, text=True, check=True).stdout
+            for line in results.splitlines():
+                if "+" in line and line not in found:
+                    found.append(line)
+        except subprocess.CalledProcessError:
             pass
 
-try:
-    if found[0] != "":
-        print("[*] Dirb found the following items...")
-        for item in found:
-            print("   " + item)
-except:
-    print("INFO: No items found during dirb scan of " + url)
+if found:
+    print("[*] Dirb found the following items...")
+    for item in found:
+        print(f"   {item}")
+else:
+    print(f"INFO: No items found during dirb scan of {url}")

--- a/recon_enum/dirbust.py
+++ b/recon_enum/dirbust.py
@@ -1,11 +1,11 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import os
 import subprocess
 
 if len(sys.argv) != 5:
-    print "Usage: dirbust.py <target url> <port> <scan name> <log directory>"
+    print("Usage: dirbust.py <target url> <port> <scan name> <log directory>")
     sys.exit(0)
 
 url = str(sys.argv[1])
@@ -19,28 +19,27 @@ if not os.path.exists(directory):
     os.makedirs(directory)
 
 found = []
-print "INFO: Starting dirb scan for " + url
+print("INFO: Starting dirb scan for " + url)
 for folder in folders:
     for filename in os.listdir(folder):
-
-		outfile = "-o %s/%s/dirb/%s/%s_dirb_%s" % (log_dir, name, port, name, filename)
-		#outfile = " -o " + "results/exam/" + name + "_dirb_" + filename
-		DIRBSCAN = "dirb %s:%s %s/%s %s -S -r" % (url, port, folder, filename, outfile)
-		print DIRBSCAN
-		try:
-			results = subprocess.check_output(DIRBSCAN, shell=True)
-			resultarr = results.split("\n")
-			for line in resultarr:
-				if "+" in line:
-					if line not in found:
-						found.append(line)
-		except:
-			pass
+        outfile = "-o %s/%s/dirb/%s/%s_dirb_%s" % (log_dir, name, port, name, filename)
+        #outfile = " -o " + "results/exam/" + name + "_dirb_" + filename
+        DIRBSCAN = "dirb %s:%s %s/%s %s -S -r" % (url, port, folder, filename, outfile)
+        print(DIRBSCAN)
+        try:
+            results = subprocess.check_output(DIRBSCAN, shell=True).decode('utf-8')
+            resultarr = results.split("\n")
+            for line in resultarr:
+                if "+" in line:
+                    if line not in found:
+                        found.append(line)
+        except:
+            pass
 
 try:
     if found[0] != "":
-        print "[*] Dirb found the following items..."
+        print("[*] Dirb found the following items...")
         for item in found:
-            print "   " + item
+            print("   " + item)
 except:
-    print "INFO: No items found during dirb scan of " + url		
+    print("INFO: No items found during dirb scan of " + url)

--- a/recon_enum/reconscan.py
+++ b/recon_enum/reconscan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import subprocess
 import multiprocessing
 import os
@@ -28,13 +28,13 @@ def connect_to_port(ip_address, port, service):
 
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.connect((ip_address, int(port)))
-    banner = s.recv(1024)
+    banner = s.recv(1024).decode('utf-8', errors='replace')
 
     if service == "ftp":
-        s.send("USER anonymous\r\n")
-        user = s.recv(1024)
-        s.send("PASS anonymous\r\n")
-        password = s.recv(1024)
+        s.send(b"USER anonymous\r\n")
+        user = s.recv(1024).decode('utf-8', errors='replace')
+        s.send(b"PASS anonymous\r\n")
+        password = s.recv(1024).decode('utf-8', errors='replace')
         total_communication = banner + "\r\n" + user + "\r\n" + password
         write_to_file(ip_address, "ftp-connect", total_communication)
     elif service == "smtp":
@@ -44,11 +44,11 @@ def connect_to_port(ip_address, port, service):
         total_communication = banner
         write_to_file(ip_address, "ssh-connect", total_communication)
     elif service == "pop3":
-        s.send("USER root\r\n")
-        user = s.recv(1024)
-        s.send("PASS root\r\n")
-        password = s.recv(1024)
-        total_communication = banner +  user +  password
+        s.send(b"USER root\r\n")
+        user = s.recv(1024).decode('utf-8', errors='replace')
+        s.send(b"PASS root\r\n")
+        password = s.recv(1024).decode('utf-8', errors='replace')
+        total_communication = banner + user + password
         write_to_file(ip_address, "pop3-connect", total_communication)
     s.close()
 
@@ -57,7 +57,7 @@ def write_to_file(ip_address, enum_type, data):
     file_path_linux = '../reports/%s/mapping-linux.md' % (ip_address)
     file_path_windows = '../reports/%s/mapping-windows.md' % (ip_address)
     paths = [file_path_linux, file_path_windows]
-    print bcolors.OKGREEN + "INFO: Writing " + enum_type + " to template files:\n" + file_path_linux + "\n" + file_path_windows + bcolors.ENDC
+    print(bcolors.OKGREEN + "INFO: Writing " + enum_type + " to template files:\n" + file_path_linux + "\n" + file_path_windows + bcolors.ENDC)
 
     search_string = ''
     if enum_type == "portscan":
@@ -94,28 +94,28 @@ def write_to_file(ip_address, enum_type, data):
     return
 
 def dirb(ip_address, port, url_start, wordlist="/usr/share/wordlists/dirb/common.txt"):
-    print bcolors.HEADER + "INFO: Starting dirb scan for " + ip_address + ":" + port + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Starting dirb scan for " + ip_address + ":" + port + bcolors.ENDC)
     DIRBSCAN = "dirb %s://%s:%s %s -o ../reports/%s/dirb-%s-%s.txt -r" % (url_start, ip_address, port, wordlist, ip_address, ip_address, port)
-    print bcolors.HEADER + DIRBSCAN + bcolors.ENDC
-    results_dirb = subprocess.check_output(DIRBSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with dirb scan for " + ip_address + bcolors.ENDC
-    print results_dirb
+    print(bcolors.HEADER + DIRBSCAN + bcolors.ENDC)
+    results_dirb = subprocess.check_output(DIRBSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with dirb scan for " + ip_address + bcolors.ENDC)
+    print(results_dirb)
     write_to_file(ip_address, "dirb", results_dirb)
     return
 
 def nikto(ip_address, port, url_start):
-    print bcolors.HEADER + "INFO: Starting nikto scan for " + ip_address + ":" + port + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Starting nikto scan for " + ip_address + ":" + port + bcolors.ENDC)
     NIKTOSCAN = "nikto -h %s://%s:%s -o ../reports/%s/nikto-%s-%s.txt" % (url_start, ip_address, port, ip_address, ip_address, port)
-    print bcolors.HEADER + NIKTOSCAN + bcolors.ENDC
-    results_nikto = subprocess.check_output(NIKTOSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with NIKTO-scan for " + ip_address + bcolors.ENDC
-    print results_nikto
+    print(bcolors.HEADER + NIKTOSCAN + bcolors.ENDC)
+    results_nikto = subprocess.check_output(NIKTOSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with NIKTO-scan for " + ip_address + bcolors.ENDC)
+    print(results_nikto)
     write_to_file(ip_address, "nikto", results_nikto)
     return
 
 def httpEnum(ip_address, port):
-    print bcolors.HEADER + "INFO: Detected http on " + ip_address + ":" + port + bcolors.ENDC
-    print bcolors.HEADER + "INFO: Performing nmap web script scan for " + ip_address + ":" + port + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Detected http on " + ip_address + ":" + port + bcolors.ENDC)
+    print(bcolors.HEADER + "INFO: Performing nmap web script scan for " + ip_address + ":" + port + bcolors.ENDC)
 
     dirb_process = multiprocessing.Process(target=dirb, args=(ip_address, port, "http"))
     dirb_process.start()
@@ -123,29 +123,29 @@ def httpEnum(ip_address, port):
     nikto_process.start()
 
     CURLSCAN = "curl -I http://%s" % (ip_address)
-    print bcolors.HEADER + CURLSCAN + bcolors.ENDC
-    curl_results = subprocess.check_output(CURLSCAN, shell=True)
+    print(bcolors.HEADER + CURLSCAN + bcolors.ENDC)
+    curl_results = subprocess.check_output(CURLSCAN, shell=True).decode('utf-8')
     write_to_file(ip_address, "curl", curl_results)
     HTTPSCAN = "nmap -n -sV -Pn -p %s --script=http-vhosts,http-userdir-enum,http-apache-negotiation,http-backup-finder,http-config-backup,http-default-accounts,http-methods,http-method-tamper,http-passwd,http-robots.txt,http-devframework,http-enum,http-frontpage-login,http-git,http-iis-webdav-vuln,http-php-version,http-robots.txt,http-shellshock,http-vuln-cve2015-1635 -oN ../reports/%s/%s_http.nmap %s" % (port, ip_address, ip_address, ip_address)
-    print bcolors.HEADER + HTTPSCAN + bcolors.ENDC
+    print(bcolors.HEADER + HTTPSCAN + bcolors.ENDC)
 
-    http_results = subprocess.check_output(HTTPSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with HTTP-SCAN for " + ip_address + bcolors.ENDC
-    print http_results
-    
+    http_results = subprocess.check_output(HTTPSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with HTTP-SCAN for " + ip_address + bcolors.ENDC)
+    print(http_results)
+
     if "Drupal" in http_results:
-        print bcolors.HEADER + "INFO: Detected Drupal on " + ip_address + ":" + port + bcolors.ENDC
-        print bcolors.HEADER + "INFO: Performing Drupal scan for " + ip_address + ":" + port + bcolors.ENDC
+        print(bcolors.HEADER + "INFO: Detected Drupal on " + ip_address + ":" + port + bcolors.ENDC)
+        print(bcolors.HEADER + "INFO: Performing Drupal scan for " + ip_address + ":" + port + bcolors.ENDC)
         DRUPALSCAN = "droopescan scan drupal -u http://%s:%s | tee ../reports/%s/droopescan_%s.txt" % (ip_address, port, ip_address, port)
-        drupal_results = subprocess.check_output(DRUPALSCAN, shell=True)
-        print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with DRUPAL-SCAN for " + ip_address + bcolors.ENDC
-        print drupal_results
+        drupal_results = subprocess.check_output(DRUPALSCAN, shell=True).decode('utf-8')
+        print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with DRUPAL-SCAN for " + ip_address + bcolors.ENDC)
+        print(drupal_results)
 
     return
 
 def httpsEnum(ip_address, port):
-    print bcolors.HEADER + "INFO: Detected https on " + ip_address + ":" + port + bcolors.ENDC
-    print bcolors.HEADER + "INFO: Performing nmap web script scan for " + ip_address + ":" + port + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Detected https on " + ip_address + ":" + port + bcolors.ENDC)
+    print(bcolors.HEADER + "INFO: Performing nmap web script scan for " + ip_address + ":" + port + bcolors.ENDC)
 
     dirb_process = multiprocessing.Process(target=dirb, args=(ip_address, port, "https"))
     dirb_process.start()
@@ -153,134 +153,134 @@ def httpsEnum(ip_address, port):
     nikto_process.start()
 
     SSLSCAN = "sslscan %s:%s >> ../reports/%s/ssl_scan_%s_%s.txt" % (ip_address, port, ip_address, ip_address, port)
-    print bcolors.HEADER + SSLSCAN + bcolors.ENDC
+    print(bcolors.HEADER + SSLSCAN + bcolors.ENDC)
     subprocess.check_output(SSLSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: CHECK FILE - Finished with SSLSCAN for " + ip_address + ":" + port + bcolors.ENDC
+    print(bcolors.OKGREEN + "INFO: CHECK FILE - Finished with SSLSCAN for " + ip_address + ":" + port + bcolors.ENDC)
 
     HTTPSCANS = "nmap -n -sV -Pn -p %s --script=http-vhosts,http-userdir-enum,http-apache-negotiation,http-backup-finder,http-config-backup,http-default-accounts,http-methods,http-method-tamper,http-passwd,http-robots.txt,http-devframework,http-enum,http-frontpage-login,http-git,http-iis-webdav-vuln,http-php-version,http-robots.txt,http-shellshock,http-vuln-cve2015-1635 -oN ../reports/%s/%s_http.nmap %s" % (port, ip_address, ip_address, ip_address)
-    print bcolors.HEADER + HTTPSCANS + bcolors.ENDC
-    https_results = subprocess.check_output(HTTPSCANS, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with HTTPS-scan for " + ip_address + ":" + port + bcolors.ENDC
-    print https_results
+    print(bcolors.HEADER + HTTPSCANS + bcolors.ENDC)
+    https_results = subprocess.check_output(HTTPSCANS, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with HTTPS-scan for " + ip_address + bcolors.ENDC)
+    print(https_results)
     return
 
 def mssqlEnum(ip_address, port):
-    print bcolors.HEADER + "INFO: Detected MS-SQL on " + ip_address + ":" + port + bcolors.ENDC
-    print bcolors.HEADER + "INFO: Performing nmap mssql script scan for " + ip_address + ":" + port + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Detected MS-SQL on " + ip_address + ":" + port + bcolors.ENDC)
+    print(bcolors.HEADER + "INFO: Performing nmap mssql script scan for " + ip_address + ":" + port + bcolors.ENDC)
     MSSQLSCAN = "nmap -n -sV -Pn -p %s --script=ms-sql-empty-password,ms-sql-info,ms-sql-config,ms-sql-hasdbaccess,ms-sql-dump-hashes --script-args=mssql.instance-port=%s -oN ../reports/%s/mssql_%s.nmap %s" % (port, port, ip_address, ip_address, ip_address)
-    print bcolors.HEADER + MSSQLSCAN + bcolors.ENDC
-    mssql_results = subprocess.check_output(MSSQLSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with MSSQL-scan for " + ip_address + ":" + port + bcolors.ENDC
-    print mssql_results
+    print(bcolors.HEADER + MSSQLSCAN + bcolors.ENDC)
+    mssql_results = subprocess.check_output(MSSQLSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with MSSQL-scan for " + ip_address + bcolors.ENDC)
+    print(mssql_results)
     return
 
 def mysqlEnum(ip_address, port):
-    print bcolors.HEADER + "INFO: Detected MySQL on " + ip_address + ":" + port + bcolors.ENDC
-    print bcolors.HEADER + "INFO: Performing nmap mysql script scan for " + ip_address + ":" + port + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Detected MySQL on " + ip_address + ":" + port + bcolors.ENDC)
+    print(bcolors.HEADER + "INFO: Performing nmap mysql script scan for " + ip_address + ":" + port + bcolors.ENDC)
     MYSQLSCAN = "nmap -n -sV -Pn -p %s --script=mysql-empty-password,mysql-enum,mysql-users,mysql-variables,mysql-vuln-cve2012-2122 -oN ../reports/%s/mysql_%s.nmap %s" % (port, ip_address, ip_address, ip_address)
-    print bcolors.HEADER + MYSQLSCAN + bcolors.ENDC
-    mysql_results = subprocess.check_output(MYSQLSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with MySQL-scan for " + ip_address + ":" + port + bcolors.ENDC
-    print mysql_results
+    print(bcolors.HEADER + MYSQLSCAN + bcolors.ENDC)
+    mysql_results = subprocess.check_output(MYSQLSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with MySQL-scan for " + ip_address + bcolors.ENDC)
+    print(mysql_results)
     return
 
 def oracleEnum(ip_address, port):
-    print bcolors.HEADER + "INFO: Detected Oracle on " + ip_address + ":" + port + bcolors.ENDC
-    print bcolors.HEADER + "INFO: Performing nmap oracle script scan for " + ip_address + ":" + port + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Detected Oracle on " + ip_address + ":" + port + bcolors.ENDC)
+    print(bcolors.HEADER + "INFO: Performing nmap oracle script scan for " + ip_address + ":" + port + bcolors.ENDC)
     ORACLESCAN = "nmap -n -sV -Pn -p %s --script=oracle-tns-version,oracle-sid-brute,oracle-enum-users -oN ../reports/%s/oracle_%s.nmap %s" % (port, ip_address, ip_address, ip_address)
-    print bcolors.HEADER + ORACLESCAN + bcolors.ENDC
-    oracle_results = subprocess.check_output(ORACLESCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with Oracle-scan for " + ip_address + ":" + port + bcolors.ENDC
-    print oracle_results
+    print(bcolors.HEADER + ORACLESCAN + bcolors.ENDC)
+    oracle_results = subprocess.check_output(ORACLESCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with Oracle-scan for " + ip_address + bcolors.ENDC)
+    print(oracle_results)
     return
 
 def smtpEnum(ip_address, port):
-    print bcolors.HEADER + "INFO: Detected smtp on " + ip_address + ":" + port  + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Detected smtp on " + ip_address + ":" + port + bcolors.ENDC)
     connect_to_port(ip_address, port, "smtp")
     SMTPSCAN = "nmap -n -sV -Pn -p %s --script=smtp-commands,smtp-enum-users,smtp-vuln-cve2010-4344,smtp-vuln-cve2011-1720,smtp-vuln-cve2011-1764 %s -oN ../reports/%s/smtp_%s.nmap" % (port, ip_address, ip_address, ip_address)
-    print bcolors.HEADER + SMTPSCAN + bcolors.ENDC
-    smtp_results = subprocess.check_output(SMTPSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SMTP-scan for " + ip_address + ":" + port + bcolors.ENDC
-    print smtp_results
+    print(bcolors.HEADER + SMTPSCAN + bcolors.ENDC)
+    smtp_results = subprocess.check_output(SMTPSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SMTP-scan for " + ip_address + ":" + port + bcolors.ENDC)
+    print(smtp_results)
     return
 
 def smbNmap(ip_address, ports):
-    print bcolors.HEADER + "INFO: Detected SMB on " + ip_address + " on " + ports
+    print(bcolors.HEADER + "INFO: Detected SMB on " + ip_address + " on " + ports)
     smb_nmap = "nmap -n -p %s --script=smb-enum-shares,smb-ls,smb-enum-users,smb-mbenum,smb-os-discovery,smb-security-mode,msrpc-enum,smb-vuln-cve2009-3103,smb-vuln-cve-2017-7494,smb-vuln-ms06-025,smb-vuln-ms07-029,smb-vuln-ms08-067,smb-vuln-ms10-054,smb-vuln-ms10-061,smb-vuln-ms17-010 %s -oN ../reports/%s/smb_%s_%s.nmap" % (ports, ip_address, ip_address, ip_address, ports.replace(",", "_"))
-    smbNmap_results = subprocess.check_output(smb_nmap, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SMB-Nmap-scan for " + ip_address + " for ports " + ports + bcolors.ENDC
-    print smbNmap_results
+    smbNmap_results = subprocess.check_output(smb_nmap, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SMB-Nmap-scan for " + ip_address + " for ports " + ports + bcolors.ENDC)
+    print(smbNmap_results)
     return
 
 def smbEnum(ip_address, port):
-    print bcolors.HEADER + "INFO: Detected SMB on " + ip_address
+    print(bcolors.HEADER + "INFO: Detected SMB on " + ip_address)
     enum4linux = "enum4linux -a %s > ../reports/%s/enum4linux_%s.txt 2>/dev/null" % (ip_address, ip_address, ip_address)
-    enum4linux_results = subprocess.check_output(enum4linux, shell=True)
-    print bcolors.OKGREEN + "INFO: CHECK FILE - Finished with SMB-enum4linux for " + ip_address + bcolors.ENDC
-    print enum4linux_results
+    enum4linux_results = subprocess.check_output(enum4linux, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: CHECK FILE - Finished with SMB-enum4linux for " + ip_address + bcolors.ENDC)
+    print(enum4linux_results)
     smbmap = "smbmap -H %s" % (ip_address)
-    smbmap_results = subprocess.check_output(smbmap, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SMB-smbmap for " + ip_address + bcolors.ENDC
-    print smbmap_results
+    smbmap_results = subprocess.check_output(smbmap, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SMB-smbmap for " + ip_address + bcolors.ENDC)
+    print(smbmap_results)
     NBTSCAN = "nbtscan -r %s/32" % (ip_address)
-    nbtresults = subprocess.check_output(NBTSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SMB-nbtscan for " + ip_address + bcolors.ENDC
-    print nbtresults
+    nbtresults = subprocess.check_output(NBTSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SMB-nbtscan for " + ip_address + bcolors.ENDC)
+    print(nbtresults)
     return
 
 def ftpEnum(ip_address, port):
-    print bcolors.HEADER + "INFO: Detected ftp on " + ip_address + ":" + port  + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Detected ftp on " + ip_address + ":" + port + bcolors.ENDC)
     connect_to_port(ip_address, port, "ftp")
     FTPSCAN = "nmap -n -sV -Pn -p %s --script=ftp-anon,ftp-bounce,ftp-libopie,ftp-proftpd-backdoor,ftp-vsftpd-backdoor,ftp-vuln-cve2010-4221 -oN '../reports/%s/ftp_%s.nmap' %s" % (port, ip_address, ip_address, ip_address)
-    print bcolors.HEADER + FTPSCAN + bcolors.ENDC
-    results_ftp = subprocess.check_output(FTPSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with FTP-Nmap-scan for " + ip_address + bcolors.ENDC
-    print results_ftp
+    print(bcolors.HEADER + FTPSCAN + bcolors.ENDC)
+    results_ftp = subprocess.check_output(FTPSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with FTP-Nmap-scan for " + ip_address + bcolors.ENDC)
+    print(results_ftp)
     return
 
 def udpScan(ip_address, ports):
-    print bcolors.HEADER + "INFO: Detecting UDP on " + ip_address + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Detecting UDP on " + ip_address + bcolors.ENDC)
     UDPSCAN = "nmap -n -Pn -A -sC -sU -T 3 -p %s -oA '../reports/%s/udp_%s' %s"  % (ports, ip_address, ip_address, ip_address)
-    print bcolors.HEADER + UDPSCAN + bcolors.ENDC
-    udpscan_results = subprocess.check_output(UDPSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with UDP-Nmap scan for " + ip_address + bcolors.ENDC
-    print udpscan_results
+    print(bcolors.HEADER + UDPSCAN + bcolors.ENDC)
+    udpscan_results = subprocess.check_output(UDPSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with UDP-Nmap scan for " + ip_address + bcolors.ENDC)
+    print(udpscan_results)
     #UNICORNSCAN = "unicornscan -mU -I %s > ../reports/%s/unicorn_udp_%s.txt" % (ip_address, ip_address, ip_address)
     #subprocess.check_output(UNICORNSCAN, shell=True)
-    #print bcolors.OKGREEN + "INFO: CHECK FILE - Finished with UNICORNSCAN for " + ip_address + bcolors.ENDC
+    #print(bcolors.OKGREEN + "INFO: CHECK FILE - Finished with UNICORNSCAN for " + ip_address + bcolors.ENDC)
 
 def udpTopScan(ip_address):
-    print bcolors.HEADER + "INFO: Detecting UDP on Top 200 ports on " + ip_address + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Detecting UDP on Top 200 ports on " + ip_address + bcolors.ENDC)
     UDPSCAN = "nmap -n -Pn -A -sC -sU -T 3 --top-ports 200 -oA '../reports/%s/udp_%s_200' %s"  % (ip_address, ip_address, ip_address)
-    print bcolors.HEADER + UDPSCAN + bcolors.ENDC
-    udpscan_results = subprocess.check_output(UDPSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with UDP-Nmap Top 200 scan for " + ip_address + bcolors.ENDC
-    print udpscan_results
+    print(bcolors.HEADER + UDPSCAN + bcolors.ENDC)
+    udpscan_results = subprocess.check_output(UDPSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with UDP-Nmap Top 200 scan for " + ip_address + bcolors.ENDC)
+    print(udpscan_results)
 
 def sshScan(ip_address, port):
-    print bcolors.HEADER + "INFO: Detected SSH on " + ip_address + ":" + port  + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Detected SSH on " + ip_address + ":" + port + bcolors.ENDC)
     connect_to_port(ip_address, port, "ssh")
     SSHSCAN = "nmap -n -sV -Pn -p %s --script=ssh-auth-methods,ssh-hostkey,ssh-run,sshv1 -oN '../reports/%s/ssh_%s.nmap' %s" % (port, ip_address, ip_address, ip_address)
-    print bcolors.HEADER + SSHSCAN + bcolors.ENDC
-    results_ssh = subprocess.check_output(SSHSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SSH-Nmap-scan for " + ip_address + bcolors.ENDC
-    print results_ssh
+    print(bcolors.HEADER + SSHSCAN + bcolors.ENDC)
+    results_ssh = subprocess.check_output(SSHSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SSH-Nmap-scan for " + ip_address + bcolors.ENDC)
+    print(results_ssh)
     return
 
 def pop3Scan(ip_address, port):
-    print bcolors.HEADER + "INFO: Detected POP3 on " + ip_address + ":" + port + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Detected POP3 on " + ip_address + ":" + port + bcolors.ENDC)
     connect_to_port(ip_address, port, "pop3")
     POP3SCAN = "nmap -n -sV -Pn -p %s --script=pop3-brute,pop3-capabilities,pop3-ntlm-info -oN '../reports/%s/pop3_%s.nmap' %s" % (port, ip_address, ip_address, ip_address)
-    print bcolors.HEADER + POP3SCAN + bcolors.ENDC
-    results_pop3 = subprocess.check_output(POP3SCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with POP3-Nmap-scan for " + ip_address + ":" + port + bcolors.ENDC
-    print results_pop3
+    print(bcolors.HEADER + POP3SCAN + bcolors.ENDC)
+    results_pop3 = subprocess.check_output(POP3SCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with POP3-Nmap-scan for " + ip_address + ":" + port + bcolors.ENDC)
+    print(results_pop3)
     return
 
 def snmpEnum(ip_address, port):
-    print bcolors.HEADER + "INFO: Detected SNMP on " + ip_address + ":" + port + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Detected SNMP on " + ip_address + ":" + port + bcolors.ENDC)
     onesixtyone = "onesixtyone %s > ../reports/%s/onesixtyone_%s.txt 2>/dev/null" % (ip_address, ip_address, ip_address)
-    onesixtyone_results = subprocess.check_output(onesixtyone, shell=True)
+    onesixtyone_results = subprocess.check_output(onesixtyone, shell=True).decode('utf-8')
     if onesixtyone_results != "":
         if "Windows" in onesixtyone_results:
             results = onesixtyone_results.split("Software: ")[1]
@@ -289,57 +289,57 @@ def snmpEnum(ip_address, port):
             results = onesixtyone_results.split("[public] ")[1]
             snmpdetect = 1
         if snmpdetect == 1:
-            print bcolors.OKGREEN + "[*] SNMP running on " + ip_address + "; OS Detect: " + results
+            print(bcolors.OKGREEN + "[*] SNMP running on " + ip_address + "; OS Detect: " + results)
             SNMPWALK = "snmpwalk -c public -v1 %s 1 > ../reports/%s/snmpwalk_%s.txt 2>/dev/null" % (ip_address, ip_address, ip_address)
-            results = subprocess.check_output(SNMPWALK, shell=True)
+            results = subprocess.check_output(SNMPWALK, shell=True).decode('utf-8')
 
     SNMPSCAN = "nmap -n -vv -sV -sU -Pn -p 161,162 --script=snmp-netstat,snmp-processes -oN '../reports/%s/snmp_%s.nmap' %s" % (ip_address, ip_address, ip_address)
-    results_snmp = subprocess.check_output(SNMPSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SNMP-Nmap-scan for " + ip_address + ":" + port + bcolors.ENDC
-    print results_snmp
+    results_snmp = subprocess.check_output(SNMPSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SNMP-Nmap-scan for " + ip_address + ":" + port + bcolors.ENDC)
+    print(results_snmp)
     return
 
 def nfsScan(ip_address, port):
-    print bcolors.HEADER + "INFO: Detected RPCBIND on " + ip_address + ":" + port + bcolors.ENDC
+    print(bcolors.HEADER + "INFO: Detected RPCBIND on " + ip_address + ":" + port + bcolors.ENDC)
     NFSSCAN = "nmap -n -sS -Pn -p %s --script=nfs* -oN '../reports/%s/nfs_%s.nmap' %s" % (port, ip_address, ip_address, ip_address)
-    print bcolors.HEADER + NFSSCAN + bcolors.ENDC
-    results_nfs = subprocess.check_output(NFSSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with NFS-Nmap-scan for " + ip_address + ":" + port + bcolors.ENDC
-    print results_nfs
+    print(bcolors.HEADER + NFSSCAN + bcolors.ENDC)
+    results_nfs = subprocess.check_output(NFSSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with NFS-Nmap-scan for " + ip_address + ":" + port + bcolors.ENDC)
+    print(results_nfs)
 
     write_to_file(ip_address, "nfs", results_nfs)
     return
 
 def masscan(ip_address):
     ip_address = ip_address.strip()
-    print bcolors.OKGREEN + "INFO: Running masscan for " + ip_address + bcolors.ENDC
+    print(bcolors.OKGREEN + "INFO: Running masscan for " + ip_address + bcolors.ENDC)
 
     #MASSCAN = "masscan -e tun0 -p1-65535,U:1-65535 --rate 300 --interactive %s -oG '../reports/%s/masscan.txt'" % (ip_address, ip_address)
     #MASSCAN = "masscan -e eth0 --router-mac 8c-85-90-00-1c-88  -p1-65535,U:1-65535 --rate 1000 %s | tee '../reports/%s/masscan.txt'" % (ip_address, ip_address)
     MASSCAN = "masscan -e tun0 -p1-65535,U:1-65535 --rate 1000 %s | tee '../reports/%s/masscan.txt'" % (ip_address, ip_address)
-    print bcolors.HEADER + MASSCAN + bcolors.ENDC
-    output = subprocess.check_output(MASSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with masscan for " + ip_address + bcolors.ENDC
-    print output
-    
+    print(bcolors.HEADER + MASSCAN + bcolors.ENDC)
+    output = subprocess.check_output(MASSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with masscan for " + ip_address + bcolors.ENDC)
+    print(output)
+
     # Get discovered TCP ports from the masscan output, sort them and run nmap for those
-    results = re.findall('port (\d*)/tcp', output)
+    results = re.findall(r'port (\d*)/tcp', output)
     if results:
         tcp_ports = list({int(port) for port in results})
         tcp_ports.sort()
         tcp_ports = ''.join(str(tcp_ports)[1:-1].split())
-        
+
         # Running nmap
         p = multiprocessing.Process(target=nmapScan, args=(ip_address, tcp_ports))
         p.start()
 
     # Get discovered UDP ports from the masscan output, sort them and run nmap for those
-    results = re.findall('port (\d*)/udp', output)
+    results = re.findall(r'port (\d*)/udp', output)
     if results:
         udp_ports = list({int(port) for port in results})
         udp_ports.sort()
         udp_ports = ''.join(str(udp_ports)[1:-1].split())
-        
+
         # Running nmap
         p = multiprocessing.Process(target=udpScan, args=(ip_address, udp_ports))
         p.start()
@@ -350,13 +350,13 @@ def masscan(ip_address):
 
 def nmapScan(ip_address, ports):
     ip_address = ip_address.strip()
-    print bcolors.OKGREEN + "INFO: Running general TCP nmap scans for " + ip_address + bcolors.ENDC
+    print(bcolors.OKGREEN + "INFO: Running general TCP nmap scans for " + ip_address + bcolors.ENDC)
 
     TCPSCAN = "nmap -n -A -p %s %s -oA '../reports/%s/tcp_%s'"  % (ports, ip_address, ip_address, ip_address)
-    print bcolors.HEADER + TCPSCAN + bcolors.ENDC
-    results = subprocess.check_output(TCPSCAN, shell=True)
-    print bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with Nmap scan for " + ip_address + bcolors.ENDC
-    print results
+    print(bcolors.HEADER + TCPSCAN + bcolors.ENDC)
+    results = subprocess.check_output(TCPSCAN, shell=True).decode('utf-8')
+    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with Nmap scan for " + ip_address + bcolors.ENDC)
+    print(results)
 
     #p = multiprocessing.Process(target=udpScan, args=(ip_address,))
     #p.start()
@@ -440,25 +440,25 @@ def nmapScan(ip_address, ports):
     return
 
 
-print bcolors.HEADER
-print "------------------------------------------------------------"
-print "!!!!                      RECON SCAN                   !!!!!"
-print "!!!!            A multi-process service scanner        !!!!!"
-print "!!!!        dirb, nikto, ftp, ssh, mssql, pop3, tcp    !!!!!"
-print "!!!!                    udp, smtp, smb                 !!!!!"
-print "------------------------------------------------------------"
+print(bcolors.HEADER)
+print("------------------------------------------------------------")
+print("!!!!                      RECON SCAN                   !!!!!")
+print("!!!!            A multi-process service scanner        !!!!!")
+print("!!!!        dirb, nikto, ftp, ssh, mssql, pop3, tcp    !!!!!")
+print("!!!!                    udp, smtp, smb                 !!!!!")
+print("------------------------------------------------------------")
 
 
 
 if len(sys.argv) < 2:
-    print ""
-    print "Usage: python reconscan.py <ip> <ip> <ip>"
-    print "Example: python reconscan.py 192.168.1.101 192.168.1.102"
-    print ""
-    print "############################################################"
+    print("")
+    print("Usage: python reconscan.py <ip> <ip> <ip>")
+    print("Example: python reconscan.py 192.168.1.101 192.168.1.102")
+    print("")
+    print("############################################################")
     sys.exit()
 
-print bcolors.ENDC
+print(bcolors.ENDC)
 
 if __name__ == '__main__':
 
@@ -470,14 +470,14 @@ if __name__ == '__main__':
     for scanip in targets:
         scanip = scanip.rstrip()
         if not scanip in dirs:
-            print bcolors.HEADER + "INFO: No folder was found for " + scanip + ". Setting up folder." + bcolors.ENDC
+            print(bcolors.HEADER + "INFO: No folder was found for " + scanip + ". Setting up folder." + bcolors.ENDC)
             subprocess.check_output("mkdir ../reports/" + scanip, shell=True)
             subprocess.check_output("mkdir ../reports/" + scanip + "/exploits", shell=True)
             subprocess.check_output("mkdir ../reports/" + scanip + "/privesc", shell=True)
-            print bcolors.OKGREEN + "INFO: Folder created here: " + "../reports/" + scanip + bcolors.ENDC
+            print(bcolors.OKGREEN + "INFO: Folder created here: " + "../reports/" + scanip + bcolors.ENDC)
         subprocess.check_output("cp ../templates/windows-template.md ../reports/" + scanip + "/mapping-windows.md", shell=True)
         subprocess.check_output("cp ../templates/linux-template.md ../reports/" + scanip + "/mapping-linux.md", shell=True)
-        print bcolors.OKGREEN + "INFO: Added pentesting templates: " + "../reports/" + scanip + bcolors.ENDC
+        print(bcolors.OKGREEN + "INFO: Added pentesting templates: " + "../reports/" + scanip + bcolors.ENDC)
         subprocess.check_output("sed -i -e 's/INSERTIPADDRESS/" + scanip + "/g' ../reports/" + scanip + "/mapping-windows.md", shell=True)
         subprocess.check_output("sed -i -e 's/INSERTIPADDRESS/" + scanip + "/g' ../reports/" + scanip + "/mapping-linux.md", shell=True)
 

--- a/recon_enum/reconscan.py
+++ b/recon_enum/reconscan.py
@@ -2,9 +2,11 @@
 import subprocess
 import multiprocessing
 import os
-import sys
-import socket
 import re
+import shutil
+import socket
+import sys
+from pathlib import Path
 
 class bcolors:
     HEADER = '\033[95m'
@@ -16,272 +18,247 @@ class bcolors:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
-# Creates a function for multiprocessing. Several things at once.
+ENUM_TYPE_PLACEHOLDERS = {
+    "portscan":    "INSERTTCPSCAN",
+    "dirb":        "INSERTDIRBSCAN",
+    "nikto":       "INSERTNIKTOSCAN",
+    "ftp-connect": "INSERTFTPTEST",
+    "smtp-connect":"INSERTSMTPCONNECT",
+    "ssh-connect": "INSERTSSHCONNECT",
+    "pop3-connect":"INSERTPOP3CONNECT",
+    "curl":        "INSERTCURLHEADER",
+    "nfs":         "INSERTRPCBIND",
+}
+
+def run(cmd):
+    return subprocess.run(cmd, shell=True, capture_output=True, text=True, check=True).stdout
+
 def multProc(targetin, scanip, port):
-    jobs = []
     p = multiprocessing.Process(target=targetin, args=(scanip, port))
-    jobs.append(p)
     p.start()
-    return
 
 def connect_to_port(ip_address, port, service):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.connect((ip_address, int(port)))
+        banner = s.recv(1024).decode('utf-8', errors='replace')
 
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.connect((ip_address, int(port)))
-    banner = s.recv(1024).decode('utf-8', errors='replace')
-
-    if service == "ftp":
-        s.send(b"USER anonymous\r\n")
-        user = s.recv(1024).decode('utf-8', errors='replace')
-        s.send(b"PASS anonymous\r\n")
-        password = s.recv(1024).decode('utf-8', errors='replace')
-        total_communication = banner + "\r\n" + user + "\r\n" + password
-        write_to_file(ip_address, "ftp-connect", total_communication)
-    elif service == "smtp":
-        total_communication = banner + "\r\n"
-        write_to_file(ip_address, "smtp-connect", total_communication)
-    elif service == "ssh":
-        total_communication = banner
-        write_to_file(ip_address, "ssh-connect", total_communication)
-    elif service == "pop3":
-        s.send(b"USER root\r\n")
-        user = s.recv(1024).decode('utf-8', errors='replace')
-        s.send(b"PASS root\r\n")
-        password = s.recv(1024).decode('utf-8', errors='replace')
-        total_communication = banner + user + password
-        write_to_file(ip_address, "pop3-connect", total_communication)
-    s.close()
+        if service == "ftp":
+            s.send(b"USER anonymous\r\n")
+            user = s.recv(1024).decode('utf-8', errors='replace')
+            s.send(b"PASS anonymous\r\n")
+            password = s.recv(1024).decode('utf-8', errors='replace')
+            write_to_file(ip_address, "ftp-connect", f"{banner}\r\n{user}\r\n{password}")
+        elif service == "smtp":
+            write_to_file(ip_address, "smtp-connect", f"{banner}\r\n")
+        elif service == "ssh":
+            write_to_file(ip_address, "ssh-connect", banner)
+        elif service == "pop3":
+            s.send(b"USER root\r\n")
+            user = s.recv(1024).decode('utf-8', errors='replace')
+            s.send(b"PASS root\r\n")
+            password = s.recv(1024).decode('utf-8', errors='replace')
+            write_to_file(ip_address, "pop3-connect", f"{banner}{user}{password}")
 
 def write_to_file(ip_address, enum_type, data):
-
-    file_path_linux = '../reports/%s/mapping-linux.md' % (ip_address)
-    file_path_windows = '../reports/%s/mapping-windows.md' % (ip_address)
-    paths = [file_path_linux, file_path_windows]
-    print(bcolors.OKGREEN + "INFO: Writing " + enum_type + " to template files:\n" + file_path_linux + "\n" + file_path_windows + bcolors.ENDC)
-
-    search_string = ''
-    if enum_type == "portscan":
-        search_string = "INSERTTCPSCAN"
-    if enum_type == "dirb":
-        search_string = "INSERTDIRBSCAN"
-    if enum_type == "nikto":
-        search_string = "INSERTNIKTOSCAN"
-    if enum_type == "ftp-connect":
-        search_string = "INSERTFTPTEST"
-    if enum_type == "smtp-connect":
-        search_string = "INSERTSMTPCONNECT"
-    if enum_type == "ssh-connect":
-        search_string = "INSERTSSHCONNECT"
-    if enum_type == "pop3-connect":
-        search_string = "INSERTPOP3CONNECT"
-    if enum_type == "curl":
-        search_string = "INSERTCURLHEADER"
-    if enum_type == "nfs":
-        search_string = "INSERTRPCBIND"
-
-    # Search and replace
+    paths = [
+        Path(f"../reports/{ip_address}/mapping-linux.md"),
+        Path(f"../reports/{ip_address}/mapping-windows.md"),
+    ]
+    print(f"{bcolors.OKGREEN}INFO: Writing {enum_type} to template files:{bcolors.ENDC}")
     for path in paths:
-        f = open(path, 'r')
-        filedata = f.read()
-        f.close()
+        print(f"  {path}")
 
-        newdata = filedata.replace(search_string, data)
-
-        f = open(path, 'w')
-        f.write(newdata)
-        f.close()
-
-    return
+    search_string = ENUM_TYPE_PLACEHOLDERS.get(enum_type, '')
+    for path in paths:
+        path.write_text(path.read_text().replace(search_string, data))
 
 def dirb(ip_address, port, url_start, wordlist="/usr/share/wordlists/dirb/common.txt"):
-    print(bcolors.HEADER + "INFO: Starting dirb scan for " + ip_address + ":" + port + bcolors.ENDC)
-    DIRBSCAN = "dirb %s://%s:%s %s -o ../reports/%s/dirb-%s-%s.txt -r" % (url_start, ip_address, port, wordlist, ip_address, ip_address, port)
-    print(bcolors.HEADER + DIRBSCAN + bcolors.ENDC)
-    results_dirb = subprocess.check_output(DIRBSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with dirb scan for " + ip_address + bcolors.ENDC)
+    print(f"{bcolors.HEADER}INFO: Starting dirb scan for {ip_address}:{port}{bcolors.ENDC}")
+    cmd = f"dirb {url_start}://{ip_address}:{port} {wordlist} -o ../reports/{ip_address}/dirb-{ip_address}-{port}.txt -r"
+    print(f"{bcolors.HEADER}{cmd}{bcolors.ENDC}")
+    results_dirb = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with dirb scan for {ip_address}{bcolors.ENDC}")
     print(results_dirb)
     write_to_file(ip_address, "dirb", results_dirb)
-    return
 
 def nikto(ip_address, port, url_start):
-    print(bcolors.HEADER + "INFO: Starting nikto scan for " + ip_address + ":" + port + bcolors.ENDC)
-    NIKTOSCAN = "nikto -h %s://%s:%s -o ../reports/%s/nikto-%s-%s.txt" % (url_start, ip_address, port, ip_address, ip_address, port)
-    print(bcolors.HEADER + NIKTOSCAN + bcolors.ENDC)
-    results_nikto = subprocess.check_output(NIKTOSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with NIKTO-scan for " + ip_address + bcolors.ENDC)
+    print(f"{bcolors.HEADER}INFO: Starting nikto scan for {ip_address}:{port}{bcolors.ENDC}")
+    cmd = f"nikto -h {url_start}://{ip_address}:{port} -o ../reports/{ip_address}/nikto-{ip_address}-{port}.txt"
+    print(f"{bcolors.HEADER}{cmd}{bcolors.ENDC}")
+    results_nikto = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with NIKTO-scan for {ip_address}{bcolors.ENDC}")
     print(results_nikto)
     write_to_file(ip_address, "nikto", results_nikto)
-    return
 
 def httpEnum(ip_address, port):
-    print(bcolors.HEADER + "INFO: Detected http on " + ip_address + ":" + port + bcolors.ENDC)
-    print(bcolors.HEADER + "INFO: Performing nmap web script scan for " + ip_address + ":" + port + bcolors.ENDC)
+    print(f"{bcolors.HEADER}INFO: Detected http on {ip_address}:{port}{bcolors.ENDC}")
+    print(f"{bcolors.HEADER}INFO: Performing nmap web script scan for {ip_address}:{port}{bcolors.ENDC}")
 
-    dirb_process = multiprocessing.Process(target=dirb, args=(ip_address, port, "http"))
-    dirb_process.start()
-    nikto_process = multiprocessing.Process(target=nikto, args=(ip_address, port, "http"))
-    nikto_process.start()
+    multiprocessing.Process(target=dirb, args=(ip_address, port, "http")).start()
+    multiprocessing.Process(target=nikto, args=(ip_address, port, "http")).start()
 
-    CURLSCAN = "curl -I http://%s" % (ip_address)
-    print(bcolors.HEADER + CURLSCAN + bcolors.ENDC)
-    curl_results = subprocess.check_output(CURLSCAN, shell=True).decode('utf-8')
+    curl_cmd = f"curl -I http://{ip_address}"
+    print(f"{bcolors.HEADER}{curl_cmd}{bcolors.ENDC}")
+    curl_results = run(curl_cmd)
     write_to_file(ip_address, "curl", curl_results)
-    HTTPSCAN = "nmap -n -sV -Pn -p %s --script=http-vhosts,http-userdir-enum,http-apache-negotiation,http-backup-finder,http-config-backup,http-default-accounts,http-methods,http-method-tamper,http-passwd,http-robots.txt,http-devframework,http-enum,http-frontpage-login,http-git,http-iis-webdav-vuln,http-php-version,http-robots.txt,http-shellshock,http-vuln-cve2015-1635 -oN ../reports/%s/%s_http.nmap %s" % (port, ip_address, ip_address, ip_address)
-    print(bcolors.HEADER + HTTPSCAN + bcolors.ENDC)
 
-    http_results = subprocess.check_output(HTTPSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with HTTP-SCAN for " + ip_address + bcolors.ENDC)
+    http_cmd = (f"nmap -n -sV -Pn -p {port} --script=http-vhosts,http-userdir-enum,http-apache-negotiation,"
+                f"http-backup-finder,http-config-backup,http-default-accounts,http-methods,http-method-tamper,"
+                f"http-passwd,http-robots.txt,http-devframework,http-enum,http-frontpage-login,http-git,"
+                f"http-iis-webdav-vuln,http-php-version,http-robots.txt,http-shellshock,http-vuln-cve2015-1635"
+                f" -oN ../reports/{ip_address}/{ip_address}_http.nmap {ip_address}")
+    print(f"{bcolors.HEADER}{http_cmd}{bcolors.ENDC}")
+    http_results = run(http_cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with HTTP-SCAN for {ip_address}{bcolors.ENDC}")
     print(http_results)
 
     if "Drupal" in http_results:
-        print(bcolors.HEADER + "INFO: Detected Drupal on " + ip_address + ":" + port + bcolors.ENDC)
-        print(bcolors.HEADER + "INFO: Performing Drupal scan for " + ip_address + ":" + port + bcolors.ENDC)
-        DRUPALSCAN = "droopescan scan drupal -u http://%s:%s | tee ../reports/%s/droopescan_%s.txt" % (ip_address, port, ip_address, port)
-        drupal_results = subprocess.check_output(DRUPALSCAN, shell=True).decode('utf-8')
-        print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with DRUPAL-SCAN for " + ip_address + bcolors.ENDC)
+        print(f"{bcolors.HEADER}INFO: Detected Drupal on {ip_address}:{port}{bcolors.ENDC}")
+        print(f"{bcolors.HEADER}INFO: Performing Drupal scan for {ip_address}:{port}{bcolors.ENDC}")
+        drupal_cmd = f"droopescan scan drupal -u http://{ip_address}:{port} | tee ../reports/{ip_address}/droopescan_{port}.txt"
+        drupal_results = run(drupal_cmd)
+        print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with DRUPAL-SCAN for {ip_address}{bcolors.ENDC}")
         print(drupal_results)
 
-    return
-
 def httpsEnum(ip_address, port):
-    print(bcolors.HEADER + "INFO: Detected https on " + ip_address + ":" + port + bcolors.ENDC)
-    print(bcolors.HEADER + "INFO: Performing nmap web script scan for " + ip_address + ":" + port + bcolors.ENDC)
+    print(f"{bcolors.HEADER}INFO: Detected https on {ip_address}:{port}{bcolors.ENDC}")
+    print(f"{bcolors.HEADER}INFO: Performing nmap web script scan for {ip_address}:{port}{bcolors.ENDC}")
 
-    dirb_process = multiprocessing.Process(target=dirb, args=(ip_address, port, "https"))
-    dirb_process.start()
-    nikto_process = multiprocessing.Process(target=nikto, args=(ip_address, port, "https"))
-    nikto_process.start()
+    multiprocessing.Process(target=dirb, args=(ip_address, port, "https")).start()
+    multiprocessing.Process(target=nikto, args=(ip_address, port, "https")).start()
 
-    SSLSCAN = "sslscan %s:%s >> ../reports/%s/ssl_scan_%s_%s.txt" % (ip_address, port, ip_address, ip_address, port)
-    print(bcolors.HEADER + SSLSCAN + bcolors.ENDC)
-    subprocess.check_output(SSLSCAN, shell=True)
-    print(bcolors.OKGREEN + "INFO: CHECK FILE - Finished with SSLSCAN for " + ip_address + ":" + port + bcolors.ENDC)
+    ssl_cmd = f"sslscan {ip_address}:{port} >> ../reports/{ip_address}/ssl_scan_{ip_address}_{port}.txt"
+    print(f"{bcolors.HEADER}{ssl_cmd}{bcolors.ENDC}")
+    subprocess.run(ssl_cmd, shell=True)
+    print(f"{bcolors.OKGREEN}INFO: CHECK FILE - Finished with SSLSCAN for {ip_address}:{port}{bcolors.ENDC}")
 
-    HTTPSCANS = "nmap -n -sV -Pn -p %s --script=http-vhosts,http-userdir-enum,http-apache-negotiation,http-backup-finder,http-config-backup,http-default-accounts,http-methods,http-method-tamper,http-passwd,http-robots.txt,http-devframework,http-enum,http-frontpage-login,http-git,http-iis-webdav-vuln,http-php-version,http-robots.txt,http-shellshock,http-vuln-cve2015-1635 -oN ../reports/%s/%s_http.nmap %s" % (port, ip_address, ip_address, ip_address)
-    print(bcolors.HEADER + HTTPSCANS + bcolors.ENDC)
-    https_results = subprocess.check_output(HTTPSCANS, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with HTTPS-scan for " + ip_address + bcolors.ENDC)
+    https_cmd = (f"nmap -n -sV -Pn -p {port} --script=http-vhosts,http-userdir-enum,http-apache-negotiation,"
+                 f"http-backup-finder,http-config-backup,http-default-accounts,http-methods,http-method-tamper,"
+                 f"http-passwd,http-robots.txt,http-devframework,http-enum,http-frontpage-login,http-git,"
+                 f"http-iis-webdav-vuln,http-php-version,http-robots.txt,http-shellshock,http-vuln-cve2015-1635"
+                 f" -oN ../reports/{ip_address}/{ip_address}_http.nmap {ip_address}")
+    print(f"{bcolors.HEADER}{https_cmd}{bcolors.ENDC}")
+    https_results = run(https_cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with HTTPS-scan for {ip_address}{bcolors.ENDC}")
     print(https_results)
-    return
 
 def mssqlEnum(ip_address, port):
-    print(bcolors.HEADER + "INFO: Detected MS-SQL on " + ip_address + ":" + port + bcolors.ENDC)
-    print(bcolors.HEADER + "INFO: Performing nmap mssql script scan for " + ip_address + ":" + port + bcolors.ENDC)
-    MSSQLSCAN = "nmap -n -sV -Pn -p %s --script=ms-sql-empty-password,ms-sql-info,ms-sql-config,ms-sql-hasdbaccess,ms-sql-dump-hashes --script-args=mssql.instance-port=%s -oN ../reports/%s/mssql_%s.nmap %s" % (port, port, ip_address, ip_address, ip_address)
-    print(bcolors.HEADER + MSSQLSCAN + bcolors.ENDC)
-    mssql_results = subprocess.check_output(MSSQLSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with MSSQL-scan for " + ip_address + bcolors.ENDC)
-    print(mssql_results)
-    return
+    print(f"{bcolors.HEADER}INFO: Detected MS-SQL on {ip_address}:{port}{bcolors.ENDC}")
+    print(f"{bcolors.HEADER}INFO: Performing nmap mssql script scan for {ip_address}:{port}{bcolors.ENDC}")
+    cmd = (f"nmap -n -sV -Pn -p {port} --script=ms-sql-empty-password,ms-sql-info,ms-sql-config,"
+           f"ms-sql-hasdbaccess,ms-sql-dump-hashes --script-args=mssql.instance-port={port}"
+           f" -oN ../reports/{ip_address}/mssql_{ip_address}.nmap {ip_address}")
+    print(f"{bcolors.HEADER}{cmd}{bcolors.ENDC}")
+    results = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with MSSQL-scan for {ip_address}{bcolors.ENDC}")
+    print(results)
 
 def mysqlEnum(ip_address, port):
-    print(bcolors.HEADER + "INFO: Detected MySQL on " + ip_address + ":" + port + bcolors.ENDC)
-    print(bcolors.HEADER + "INFO: Performing nmap mysql script scan for " + ip_address + ":" + port + bcolors.ENDC)
-    MYSQLSCAN = "nmap -n -sV -Pn -p %s --script=mysql-empty-password,mysql-enum,mysql-users,mysql-variables,mysql-vuln-cve2012-2122 -oN ../reports/%s/mysql_%s.nmap %s" % (port, ip_address, ip_address, ip_address)
-    print(bcolors.HEADER + MYSQLSCAN + bcolors.ENDC)
-    mysql_results = subprocess.check_output(MYSQLSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with MySQL-scan for " + ip_address + bcolors.ENDC)
-    print(mysql_results)
-    return
+    print(f"{bcolors.HEADER}INFO: Detected MySQL on {ip_address}:{port}{bcolors.ENDC}")
+    print(f"{bcolors.HEADER}INFO: Performing nmap mysql script scan for {ip_address}:{port}{bcolors.ENDC}")
+    cmd = (f"nmap -n -sV -Pn -p {port} --script=mysql-empty-password,mysql-enum,mysql-users,"
+           f"mysql-variables,mysql-vuln-cve2012-2122 -oN ../reports/{ip_address}/mysql_{ip_address}.nmap {ip_address}")
+    print(f"{bcolors.HEADER}{cmd}{bcolors.ENDC}")
+    results = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with MySQL-scan for {ip_address}{bcolors.ENDC}")
+    print(results)
 
 def oracleEnum(ip_address, port):
-    print(bcolors.HEADER + "INFO: Detected Oracle on " + ip_address + ":" + port + bcolors.ENDC)
-    print(bcolors.HEADER + "INFO: Performing nmap oracle script scan for " + ip_address + ":" + port + bcolors.ENDC)
-    ORACLESCAN = "nmap -n -sV -Pn -p %s --script=oracle-tns-version,oracle-sid-brute,oracle-enum-users -oN ../reports/%s/oracle_%s.nmap %s" % (port, ip_address, ip_address, ip_address)
-    print(bcolors.HEADER + ORACLESCAN + bcolors.ENDC)
-    oracle_results = subprocess.check_output(ORACLESCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with Oracle-scan for " + ip_address + bcolors.ENDC)
-    print(oracle_results)
-    return
+    print(f"{bcolors.HEADER}INFO: Detected Oracle on {ip_address}:{port}{bcolors.ENDC}")
+    print(f"{bcolors.HEADER}INFO: Performing nmap oracle script scan for {ip_address}:{port}{bcolors.ENDC}")
+    cmd = (f"nmap -n -sV -Pn -p {port} --script=oracle-tns-version,oracle-sid-brute,oracle-enum-users"
+           f" -oN ../reports/{ip_address}/oracle_{ip_address}.nmap {ip_address}")
+    print(f"{bcolors.HEADER}{cmd}{bcolors.ENDC}")
+    results = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with Oracle-scan for {ip_address}{bcolors.ENDC}")
+    print(results)
 
 def smtpEnum(ip_address, port):
-    print(bcolors.HEADER + "INFO: Detected smtp on " + ip_address + ":" + port + bcolors.ENDC)
+    print(f"{bcolors.HEADER}INFO: Detected smtp on {ip_address}:{port}{bcolors.ENDC}")
     connect_to_port(ip_address, port, "smtp")
-    SMTPSCAN = "nmap -n -sV -Pn -p %s --script=smtp-commands,smtp-enum-users,smtp-vuln-cve2010-4344,smtp-vuln-cve2011-1720,smtp-vuln-cve2011-1764 %s -oN ../reports/%s/smtp_%s.nmap" % (port, ip_address, ip_address, ip_address)
-    print(bcolors.HEADER + SMTPSCAN + bcolors.ENDC)
-    smtp_results = subprocess.check_output(SMTPSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SMTP-scan for " + ip_address + ":" + port + bcolors.ENDC)
-    print(smtp_results)
-    return
+    cmd = (f"nmap -n -sV -Pn -p {port} --script=smtp-commands,smtp-enum-users,smtp-vuln-cve2010-4344,"
+           f"smtp-vuln-cve2011-1720,smtp-vuln-cve2011-1764 {ip_address} -oN ../reports/{ip_address}/smtp_{ip_address}.nmap")
+    print(f"{bcolors.HEADER}{cmd}{bcolors.ENDC}")
+    results = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with SMTP-scan for {ip_address}:{port}{bcolors.ENDC}")
+    print(results)
 
 def smbNmap(ip_address, ports):
-    print(bcolors.HEADER + "INFO: Detected SMB on " + ip_address + " on " + ports)
-    smb_nmap = "nmap -n -p %s --script=smb-enum-shares,smb-ls,smb-enum-users,smb-mbenum,smb-os-discovery,smb-security-mode,msrpc-enum,smb-vuln-cve2009-3103,smb-vuln-cve-2017-7494,smb-vuln-ms06-025,smb-vuln-ms07-029,smb-vuln-ms08-067,smb-vuln-ms10-054,smb-vuln-ms10-061,smb-vuln-ms17-010 %s -oN ../reports/%s/smb_%s_%s.nmap" % (ports, ip_address, ip_address, ip_address, ports.replace(",", "_"))
-    smbNmap_results = subprocess.check_output(smb_nmap, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SMB-Nmap-scan for " + ip_address + " for ports " + ports + bcolors.ENDC)
-    print(smbNmap_results)
-    return
+    print(f"{bcolors.HEADER}INFO: Detected SMB on {ip_address} on {ports}")
+    cmd = (f"nmap -n -p {ports} --script=smb-enum-shares,smb-ls,smb-enum-users,smb-mbenum,smb-os-discovery,"
+           f"smb-security-mode,msrpc-enum,smb-vuln-cve2009-3103,smb-vuln-cve-2017-7494,smb-vuln-ms06-025,"
+           f"smb-vuln-ms07-029,smb-vuln-ms08-067,smb-vuln-ms10-054,smb-vuln-ms10-061,smb-vuln-ms17-010"
+           f" {ip_address} -oN ../reports/{ip_address}/smb_{ip_address}_{ports.replace(',', '_')}.nmap")
+    results = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with SMB-Nmap-scan for {ip_address} for ports {ports}{bcolors.ENDC}")
+    print(results)
 
 def smbEnum(ip_address, port):
-    print(bcolors.HEADER + "INFO: Detected SMB on " + ip_address)
-    enum4linux = "enum4linux -a %s > ../reports/%s/enum4linux_%s.txt 2>/dev/null" % (ip_address, ip_address, ip_address)
-    enum4linux_results = subprocess.check_output(enum4linux, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: CHECK FILE - Finished with SMB-enum4linux for " + ip_address + bcolors.ENDC)
+    print(f"{bcolors.HEADER}INFO: Detected SMB on {ip_address}")
+    enum4linux_results = run(f"enum4linux -a {ip_address} > ../reports/{ip_address}/enum4linux_{ip_address}.txt 2>/dev/null")
+    print(f"{bcolors.OKGREEN}INFO: CHECK FILE - Finished with SMB-enum4linux for {ip_address}{bcolors.ENDC}")
     print(enum4linux_results)
-    smbmap = "smbmap -H %s" % (ip_address)
-    smbmap_results = subprocess.check_output(smbmap, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SMB-smbmap for " + ip_address + bcolors.ENDC)
+    smbmap_results = run(f"smbmap -H {ip_address}")
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with SMB-smbmap for {ip_address}{bcolors.ENDC}")
     print(smbmap_results)
-    NBTSCAN = "nbtscan -r %s/32" % (ip_address)
-    nbtresults = subprocess.check_output(NBTSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SMB-nbtscan for " + ip_address + bcolors.ENDC)
+    nbtresults = run(f"nbtscan -r {ip_address}/32")
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with SMB-nbtscan for {ip_address}{bcolors.ENDC}")
     print(nbtresults)
-    return
 
 def ftpEnum(ip_address, port):
-    print(bcolors.HEADER + "INFO: Detected ftp on " + ip_address + ":" + port + bcolors.ENDC)
+    print(f"{bcolors.HEADER}INFO: Detected ftp on {ip_address}:{port}{bcolors.ENDC}")
     connect_to_port(ip_address, port, "ftp")
-    FTPSCAN = "nmap -n -sV -Pn -p %s --script=ftp-anon,ftp-bounce,ftp-libopie,ftp-proftpd-backdoor,ftp-vsftpd-backdoor,ftp-vuln-cve2010-4221 -oN '../reports/%s/ftp_%s.nmap' %s" % (port, ip_address, ip_address, ip_address)
-    print(bcolors.HEADER + FTPSCAN + bcolors.ENDC)
-    results_ftp = subprocess.check_output(FTPSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with FTP-Nmap-scan for " + ip_address + bcolors.ENDC)
-    print(results_ftp)
-    return
+    cmd = (f"nmap -n -sV -Pn -p {port} --script=ftp-anon,ftp-bounce,ftp-libopie,ftp-proftpd-backdoor,"
+           f"ftp-vsftpd-backdoor,ftp-vuln-cve2010-4221 -oN '../reports/{ip_address}/ftp_{ip_address}.nmap' {ip_address}")
+    print(f"{bcolors.HEADER}{cmd}{bcolors.ENDC}")
+    results = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with FTP-Nmap-scan for {ip_address}{bcolors.ENDC}")
+    print(results)
 
 def udpScan(ip_address, ports):
-    print(bcolors.HEADER + "INFO: Detecting UDP on " + ip_address + bcolors.ENDC)
-    UDPSCAN = "nmap -n -Pn -A -sC -sU -T 3 -p %s -oA '../reports/%s/udp_%s' %s"  % (ports, ip_address, ip_address, ip_address)
-    print(bcolors.HEADER + UDPSCAN + bcolors.ENDC)
-    udpscan_results = subprocess.check_output(UDPSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with UDP-Nmap scan for " + ip_address + bcolors.ENDC)
-    print(udpscan_results)
-    #UNICORNSCAN = "unicornscan -mU -I %s > ../reports/%s/unicorn_udp_%s.txt" % (ip_address, ip_address, ip_address)
-    #subprocess.check_output(UNICORNSCAN, shell=True)
-    #print(bcolors.OKGREEN + "INFO: CHECK FILE - Finished with UNICORNSCAN for " + ip_address + bcolors.ENDC)
+    print(f"{bcolors.HEADER}INFO: Detecting UDP on {ip_address}{bcolors.ENDC}")
+    cmd = f"nmap -n -Pn -A -sC -sU -T 3 -p {ports} -oA '../reports/{ip_address}/udp_{ip_address}' {ip_address}"
+    print(f"{bcolors.HEADER}{cmd}{bcolors.ENDC}")
+    results = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with UDP-Nmap scan for {ip_address}{bcolors.ENDC}")
+    print(results)
+    #UNICORNSCAN = f"unicornscan -mU -I {ip_address} > ../reports/{ip_address}/unicorn_udp_{ip_address}.txt"
+    #run(UNICORNSCAN)
+    #print(f"{bcolors.OKGREEN}INFO: CHECK FILE - Finished with UNICORNSCAN for {ip_address}{bcolors.ENDC}")
 
 def udpTopScan(ip_address):
-    print(bcolors.HEADER + "INFO: Detecting UDP on Top 200 ports on " + ip_address + bcolors.ENDC)
-    UDPSCAN = "nmap -n -Pn -A -sC -sU -T 3 --top-ports 200 -oA '../reports/%s/udp_%s_200' %s"  % (ip_address, ip_address, ip_address)
-    print(bcolors.HEADER + UDPSCAN + bcolors.ENDC)
-    udpscan_results = subprocess.check_output(UDPSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with UDP-Nmap Top 200 scan for " + ip_address + bcolors.ENDC)
-    print(udpscan_results)
+    print(f"{bcolors.HEADER}INFO: Detecting UDP on Top 200 ports on {ip_address}{bcolors.ENDC}")
+    cmd = f"nmap -n -Pn -A -sC -sU -T 3 --top-ports 200 -oA '../reports/{ip_address}/udp_{ip_address}_200' {ip_address}"
+    print(f"{bcolors.HEADER}{cmd}{bcolors.ENDC}")
+    results = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with UDP-Nmap Top 200 scan for {ip_address}{bcolors.ENDC}")
+    print(results)
 
 def sshScan(ip_address, port):
-    print(bcolors.HEADER + "INFO: Detected SSH on " + ip_address + ":" + port + bcolors.ENDC)
+    print(f"{bcolors.HEADER}INFO: Detected SSH on {ip_address}:{port}{bcolors.ENDC}")
     connect_to_port(ip_address, port, "ssh")
-    SSHSCAN = "nmap -n -sV -Pn -p %s --script=ssh-auth-methods,ssh-hostkey,ssh-run,sshv1 -oN '../reports/%s/ssh_%s.nmap' %s" % (port, ip_address, ip_address, ip_address)
-    print(bcolors.HEADER + SSHSCAN + bcolors.ENDC)
-    results_ssh = subprocess.check_output(SSHSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SSH-Nmap-scan for " + ip_address + bcolors.ENDC)
-    print(results_ssh)
-    return
+    cmd = (f"nmap -n -sV -Pn -p {port} --script=ssh-auth-methods,ssh-hostkey,ssh-run,sshv1"
+           f" -oN '../reports/{ip_address}/ssh_{ip_address}.nmap' {ip_address}")
+    print(f"{bcolors.HEADER}{cmd}{bcolors.ENDC}")
+    results = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with SSH-Nmap-scan for {ip_address}{bcolors.ENDC}")
+    print(results)
 
 def pop3Scan(ip_address, port):
-    print(bcolors.HEADER + "INFO: Detected POP3 on " + ip_address + ":" + port + bcolors.ENDC)
+    print(f"{bcolors.HEADER}INFO: Detected POP3 on {ip_address}:{port}{bcolors.ENDC}")
     connect_to_port(ip_address, port, "pop3")
-    POP3SCAN = "nmap -n -sV -Pn -p %s --script=pop3-brute,pop3-capabilities,pop3-ntlm-info -oN '../reports/%s/pop3_%s.nmap' %s" % (port, ip_address, ip_address, ip_address)
-    print(bcolors.HEADER + POP3SCAN + bcolors.ENDC)
-    results_pop3 = subprocess.check_output(POP3SCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with POP3-Nmap-scan for " + ip_address + ":" + port + bcolors.ENDC)
-    print(results_pop3)
-    return
+    cmd = (f"nmap -n -sV -Pn -p {port} --script=pop3-brute,pop3-capabilities,pop3-ntlm-info"
+           f" -oN '../reports/{ip_address}/pop3_{ip_address}.nmap' {ip_address}")
+    print(f"{bcolors.HEADER}{cmd}{bcolors.ENDC}")
+    results = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with POP3-Nmap-scan for {ip_address}:{port}{bcolors.ENDC}")
+    print(results)
 
 def snmpEnum(ip_address, port):
-    print(bcolors.HEADER + "INFO: Detected SNMP on " + ip_address + ":" + port + bcolors.ENDC)
-    onesixtyone = "onesixtyone %s > ../reports/%s/onesixtyone_%s.txt 2>/dev/null" % (ip_address, ip_address, ip_address)
-    onesixtyone_results = subprocess.check_output(onesixtyone, shell=True).decode('utf-8')
-    if onesixtyone_results != "":
+    print(f"{bcolors.HEADER}INFO: Detected SNMP on {ip_address}:{port}{bcolors.ENDC}")
+    onesixtyone_results = run(f"onesixtyone {ip_address} > ../reports/{ip_address}/onesixtyone_{ip_address}.txt 2>/dev/null")
+    snmpdetect = 0
+    if onesixtyone_results:
         if "Windows" in onesixtyone_results:
             results = onesixtyone_results.split("Software: ")[1]
             snmpdetect = 1
@@ -289,155 +266,113 @@ def snmpEnum(ip_address, port):
             results = onesixtyone_results.split("[public] ")[1]
             snmpdetect = 1
         if snmpdetect == 1:
-            print(bcolors.OKGREEN + "[*] SNMP running on " + ip_address + "; OS Detect: " + results)
-            SNMPWALK = "snmpwalk -c public -v1 %s 1 > ../reports/%s/snmpwalk_%s.txt 2>/dev/null" % (ip_address, ip_address, ip_address)
-            results = subprocess.check_output(SNMPWALK, shell=True).decode('utf-8')
+            print(f"{bcolors.OKGREEN}[*] SNMP running on {ip_address}; OS Detect: {results}")
+            run(f"snmpwalk -c public -v1 {ip_address} 1 > ../reports/{ip_address}/snmpwalk_{ip_address}.txt 2>/dev/null")
 
-    SNMPSCAN = "nmap -n -vv -sV -sU -Pn -p 161,162 --script=snmp-netstat,snmp-processes -oN '../reports/%s/snmp_%s.nmap' %s" % (ip_address, ip_address, ip_address)
-    results_snmp = subprocess.check_output(SNMPSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with SNMP-Nmap-scan for " + ip_address + ":" + port + bcolors.ENDC)
+    snmp_cmd = (f"nmap -n -vv -sV -sU -Pn -p 161,162 --script=snmp-netstat,snmp-processes"
+                f" -oN '../reports/{ip_address}/snmp_{ip_address}.nmap' {ip_address}")
+    results_snmp = run(snmp_cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with SNMP-Nmap-scan for {ip_address}:{port}{bcolors.ENDC}")
     print(results_snmp)
-    return
 
 def nfsScan(ip_address, port):
-    print(bcolors.HEADER + "INFO: Detected RPCBIND on " + ip_address + ":" + port + bcolors.ENDC)
-    NFSSCAN = "nmap -n -sS -Pn -p %s --script=nfs* -oN '../reports/%s/nfs_%s.nmap' %s" % (port, ip_address, ip_address, ip_address)
-    print(bcolors.HEADER + NFSSCAN + bcolors.ENDC)
-    results_nfs = subprocess.check_output(NFSSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with NFS-Nmap-scan for " + ip_address + ":" + port + bcolors.ENDC)
-    print(results_nfs)
-
-    write_to_file(ip_address, "nfs", results_nfs)
-    return
+    print(f"{bcolors.HEADER}INFO: Detected RPCBIND on {ip_address}:{port}{bcolors.ENDC}")
+    cmd = f"nmap -n -sS -Pn -p {port} --script=nfs* -oN '../reports/{ip_address}/nfs_{ip_address}.nmap' {ip_address}"
+    print(f"{bcolors.HEADER}{cmd}{bcolors.ENDC}")
+    results = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with NFS-Nmap-scan for {ip_address}:{port}{bcolors.ENDC}")
+    print(results)
+    write_to_file(ip_address, "nfs", results)
 
 def masscan(ip_address):
     ip_address = ip_address.strip()
-    print(bcolors.OKGREEN + "INFO: Running masscan for " + ip_address + bcolors.ENDC)
+    print(f"{bcolors.OKGREEN}INFO: Running masscan for {ip_address}{bcolors.ENDC}")
 
-    #MASSCAN = "masscan -e tun0 -p1-65535,U:1-65535 --rate 300 --interactive %s -oG '../reports/%s/masscan.txt'" % (ip_address, ip_address)
-    #MASSCAN = "masscan -e eth0 --router-mac 8c-85-90-00-1c-88  -p1-65535,U:1-65535 --rate 1000 %s | tee '../reports/%s/masscan.txt'" % (ip_address, ip_address)
-    MASSCAN = "masscan -e tun0 -p1-65535,U:1-65535 --rate 1000 %s | tee '../reports/%s/masscan.txt'" % (ip_address, ip_address)
-    print(bcolors.HEADER + MASSCAN + bcolors.ENDC)
-    output = subprocess.check_output(MASSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with masscan for " + ip_address + bcolors.ENDC)
+    #cmd = f"masscan -e tun0 -p1-65535,U:1-65535 --rate 300 --interactive {ip_address} -oG '../reports/{ip_address}/masscan.txt'"
+    #cmd = f"masscan -e eth0 --router-mac 8c-85-90-00-1c-88 -p1-65535,U:1-65535 --rate 1000 {ip_address} | tee '../reports/{ip_address}/masscan.txt'"
+    cmd = f"masscan -e tun0 -p1-65535,U:1-65535 --rate 1000 {ip_address} | tee '../reports/{ip_address}/masscan.txt'"
+    print(f"{bcolors.HEADER}{cmd}{bcolors.ENDC}")
+    output = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with masscan for {ip_address}{bcolors.ENDC}")
     print(output)
 
     # Get discovered TCP ports from the masscan output, sort them and run nmap for those
-    results = re.findall(r'port (\d*)/tcp', output)
-    if results:
-        tcp_ports = list({int(port) for port in results})
-        tcp_ports.sort()
-        tcp_ports = ''.join(str(tcp_ports)[1:-1].split())
-
-        # Running nmap
-        p = multiprocessing.Process(target=nmapScan, args=(ip_address, tcp_ports))
-        p.start()
+    tcp_results = re.findall(r'port (\d*)/tcp', output)
+    if tcp_results:
+        tcp_ports = ','.join(str(p) for p in sorted({int(p) for p in tcp_results}))
+        multiprocessing.Process(target=nmapScan, args=(ip_address, tcp_ports)).start()
 
     # Get discovered UDP ports from the masscan output, sort them and run nmap for those
-    results = re.findall(r'port (\d*)/udp', output)
-    if results:
-        udp_ports = list({int(port) for port in results})
-        udp_ports.sort()
-        udp_ports = ''.join(str(udp_ports)[1:-1].split())
-
-        # Running nmap
-        p = multiprocessing.Process(target=udpScan, args=(ip_address, udp_ports))
-        p.start()
+    udp_results = re.findall(r'port (\d*)/udp', output)
+    if udp_results:
+        udp_ports = ','.join(str(p) for p in sorted({int(p) for p in udp_results}))
+        multiprocessing.Process(target=udpScan, args=(ip_address, udp_ports)).start()
     else:
-        # Running nmap
-        p = multiprocessing.Process(target=udpTopScan, args=(ip_address,))
-        p.start()
+        multiprocessing.Process(target=udpTopScan, args=(ip_address,)).start()
 
 def nmapScan(ip_address, ports):
     ip_address = ip_address.strip()
-    print(bcolors.OKGREEN + "INFO: Running general TCP nmap scans for " + ip_address + bcolors.ENDC)
+    print(f"{bcolors.OKGREEN}INFO: Running general TCP nmap scans for {ip_address}{bcolors.ENDC}")
 
-    TCPSCAN = "nmap -n -A -p %s %s -oA '../reports/%s/tcp_%s'"  % (ports, ip_address, ip_address, ip_address)
-    print(bcolors.HEADER + TCPSCAN + bcolors.ENDC)
-    results = subprocess.check_output(TCPSCAN, shell=True).decode('utf-8')
-    print(bcolors.OKGREEN + "INFO: RESULT BELOW - Finished with Nmap scan for " + ip_address + bcolors.ENDC)
+    cmd = f"nmap -n -A -p {ports} {ip_address} -oA '../reports/{ip_address}/tcp_{ip_address}'"
+    print(f"{bcolors.HEADER}{cmd}{bcolors.ENDC}")
+    results = run(cmd)
+    print(f"{bcolors.OKGREEN}INFO: RESULT BELOW - Finished with Nmap scan for {ip_address}{bcolors.ENDC}")
     print(results)
 
-    #p = multiprocessing.Process(target=udpScan, args=(ip_address,))
-    #p.start()
-
     write_to_file(ip_address, "portscan", results)
-    lines = results.split("\n")
     serv_dict = {}
-    for line in lines:
-        ports = []
+    for line in results.splitlines():
         line = line.strip()
-        if ("tcp" in line) and ("open" in line) and not "Discovered" in line:
-            # print line
-            while "  " in line:
-                line = line.replace("  ", " ")
-            linesplit = line.split(" ")
-            service = linesplit[2] # grab the service name
-
-            port = line.split(" ")[0] # grab the port/proto
-
-            if service in serv_dict:
-                ports = serv_dict[service] # if the service is already in the dict, grab the port list
-
-            ports.append(port)
-            serv_dict[service] = ports # add service to the dictionary along with the associated port(2)
+        if "tcp" in line and "open" in line and "Discovered" not in line:
+            line = re.sub(r' +', ' ', line)
+            parts = line.split(" ")
+            service = parts[2]
+            port = parts[0]
+            serv_dict.setdefault(service, []).append(port)
 
     # go through the service dictionary to call additional targeted enumeration functions
     called_smbEnum = False
-    for serv in serv_dict:
-        ports = serv_dict[serv]
+    for serv, ports in serv_dict.items():
+        port_nums = [p.split("/")[0] for p in ports]
         if serv == "http":
-            for port in ports:
-                port = port.split("/")[0]
+            for port in port_nums:
                 multProc(httpEnum, ip_address, port)
-        elif (serv == "https") or (serv == "ssl/https"):
-            for port in ports:
-                port = port.split("/")[0]
+        elif serv in ("https", "ssl/https"):
+            for port in port_nums:
                 multProc(httpsEnum, ip_address, port)
         elif "smtp" in serv:
-            for port in ports:
-                port = port.split("/")[0]
+            for port in port_nums:
                 multProc(smtpEnum, ip_address, port)
         elif "ftp" in serv:
-            for port in ports:
-                port = port.split("/")[0]
+            for port in port_nums:
                 multProc(ftpEnum, ip_address, port)
-        elif ("microsoft-ds" in serv) or (serv == "netbios-ssn"):
-            multProc(smbNmap, ip_address, ",".join(port.split("/")[0] for port in ports))
+        elif "microsoft-ds" in serv or serv == "netbios-ssn":
+            multProc(smbNmap, ip_address, ",".join(port_nums))
             if not called_smbEnum:
-                # call SMB enum only once
                 multProc(smbEnum, ip_address, "445")
                 called_smbEnum = True
         elif "ms-sql" in serv:
-            for port in ports:
-                port = port.split("/")[0]
+            for port in port_nums:
                 multProc(mssqlEnum, ip_address, port)
         elif "mysql" in serv:
-            for port in ports:
-                port = port.split("/")[0]
+            for port in port_nums:
                 multProc(mysqlEnum, ip_address, port)
         elif "ssh" in serv:
-            for port in ports:
-                port = port.split("/")[0]
+            for port in port_nums:
                 multProc(sshScan, ip_address, port)
         elif "pop3" in serv:
-            for port in ports:
-                port = port.split("/")[0]
+            for port in port_nums:
                 multProc(pop3Scan, ip_address, port)
         elif "snmp" in serv:
-            for port in ports:
-                port = port.split("/")[0]
+            for port in port_nums:
                 multProc(snmpEnum, ip_address, port)
         elif "rpcbind" in serv:
-            for port in ports:
-                port = port.split("/")[0]
+            for port in port_nums:
                 multProc(nfsScan, ip_address, port)
         elif "oracle" in serv:
-            for port in ports:
-                port = port.split("/")[0]
+            for port in port_nums:
                 multProc(oracleEnum, ip_address, port)
-
-    return
 
 
 if __name__ == '__main__':
@@ -451,31 +386,27 @@ if __name__ == '__main__':
     print(bcolors.ENDC)
 
     if len(sys.argv) < 2:
-        print("")
-        print("Usage: python reconscan.py <ip> <ip> <ip>")
-        print("Example: python reconscan.py 192.168.1.101 192.168.1.102")
-        print("")
+        print("\nUsage: python reconscan.py <ip> <ip> <ip>")
+        print("Example: python reconscan.py 192.168.1.101 192.168.1.102\n")
         print("############################################################")
         sys.exit()
 
-    # Setting ip targets
-    targets = sys.argv
-    targets.pop(0)
+    targets = sys.argv[1:]
+    existing_dirs = os.listdir("../reports/")
 
-    dirs = os.listdir("../reports/")
     for scanip in targets:
-        scanip = scanip.rstrip()
-        if not scanip in dirs:
-            print(bcolors.HEADER + "INFO: No folder was found for " + scanip + ". Setting up folder." + bcolors.ENDC)
-            subprocess.check_output("mkdir ../reports/" + scanip, shell=True)
-            subprocess.check_output("mkdir ../reports/" + scanip + "/exploits", shell=True)
-            subprocess.check_output("mkdir ../reports/" + scanip + "/privesc", shell=True)
-            print(bcolors.OKGREEN + "INFO: Folder created here: " + "../reports/" + scanip + bcolors.ENDC)
-        subprocess.check_output("cp ../templates/windows-template.md ../reports/" + scanip + "/mapping-windows.md", shell=True)
-        subprocess.check_output("cp ../templates/linux-template.md ../reports/" + scanip + "/mapping-linux.md", shell=True)
-        print(bcolors.OKGREEN + "INFO: Added pentesting templates: " + "../reports/" + scanip + bcolors.ENDC)
-        subprocess.check_output("sed -i -e 's/INSERTIPADDRESS/" + scanip + "/g' ../reports/" + scanip + "/mapping-windows.md", shell=True)
-        subprocess.check_output("sed -i -e 's/INSERTIPADDRESS/" + scanip + "/g' ../reports/" + scanip + "/mapping-linux.md", shell=True)
+        scanip = scanip.strip()
+        if scanip not in existing_dirs:
+            print(f"{bcolors.HEADER}INFO: No folder was found for {scanip}. Setting up folder.{bcolors.ENDC}")
+            os.makedirs(f"../reports/{scanip}/exploits")
+            os.makedirs(f"../reports/{scanip}/privesc")
+            print(f"{bcolors.OKGREEN}INFO: Folder created here: ../reports/{scanip}{bcolors.ENDC}")
 
-        p = multiprocessing.Process(target=masscan, args=(scanip,))
-        p.start()
+        for template, dest in [("windows-template.md", "mapping-windows.md"),
+                                ("linux-template.md",   "mapping-linux.md")]:
+            dest_path = Path(f"../reports/{scanip}/{dest}")
+            shutil.copy(f"../templates/{template}", dest_path)
+            dest_path.write_text(dest_path.read_text().replace("INSERTIPADDRESS", scanip))
+
+        print(f"{bcolors.OKGREEN}INFO: Added pentesting templates: ../reports/{scanip}{bcolors.ENDC}")
+        multiprocessing.Process(target=masscan, args=(scanip,)).start()

--- a/recon_enum/reconscan.py
+++ b/recon_enum/reconscan.py
@@ -440,27 +440,23 @@ def nmapScan(ip_address, ports):
     return
 
 
-print(bcolors.HEADER)
-print("------------------------------------------------------------")
-print("!!!!                      RECON SCAN                   !!!!!")
-print("!!!!            A multi-process service scanner        !!!!!")
-print("!!!!        dirb, nikto, ftp, ssh, mssql, pop3, tcp    !!!!!")
-print("!!!!                    udp, smtp, smb                 !!!!!")
-print("------------------------------------------------------------")
-
-
-
-if len(sys.argv) < 2:
-    print("")
-    print("Usage: python reconscan.py <ip> <ip> <ip>")
-    print("Example: python reconscan.py 192.168.1.101 192.168.1.102")
-    print("")
-    print("############################################################")
-    sys.exit()
-
-print(bcolors.ENDC)
-
 if __name__ == '__main__':
+    print(bcolors.HEADER)
+    print("------------------------------------------------------------")
+    print("!!!!                      RECON SCAN                   !!!!!")
+    print("!!!!            A multi-process service scanner        !!!!!")
+    print("!!!!        dirb, nikto, ftp, ssh, mssql, pop3, tcp    !!!!!")
+    print("!!!!                    udp, smtp, smb                 !!!!!")
+    print("------------------------------------------------------------")
+    print(bcolors.ENDC)
+
+    if len(sys.argv) < 2:
+        print("")
+        print("Usage: python reconscan.py <ip> <ip> <ip>")
+        print("Example: python reconscan.py 192.168.1.101 192.168.1.102")
+        print("")
+        print("############################################################")
+        sys.exit()
 
     # Setting ip targets
     targets = sys.argv

--- a/recon_enum/sshrecon.py
+++ b/recon_enum/sshrecon.py
@@ -10,13 +10,12 @@ ip_address = sys.argv[1].strip()
 port = sys.argv[2].strip()
 log_dir = sys.argv[3].strip()
 
-print("INFO: Performing hydra ssh scan against " + ip_address)
-HYDRA = "hydra -L wordlists/userlist -P wordlists/offsecpass -f -o %s/%s/%s_sshhydra.txt -u %s -s %s ssh" % (log_dir, ip_address, ip_address, ip_address, port)
+print(f"INFO: Performing hydra ssh scan against {ip_address}")
+cmd = f"hydra -L wordlists/userlist -P wordlists/offsecpass -f -o {log_dir}/{ip_address}/{ip_address}_sshhydra.txt ssh://{ip_address}:{port}"
 try:
-    results = subprocess.check_output(HYDRA, shell=True).decode('utf-8')
-    resultarr = results.split("\n")
-    for result in resultarr:
+    results = subprocess.run(cmd, shell=True, capture_output=True, text=True, check=True).stdout
+    for result in results.splitlines():
         if "login:" in result:
-            print("[*] Valid ssh credentials found: " + result)
-except:
+            print(f"[*] Valid ssh credentials found: {result}")
+except subprocess.CalledProcessError:
     print("INFO: No valid ssh credentials found")

--- a/recon_enum/sshrecon.py
+++ b/recon_enum/sshrecon.py
@@ -1,22 +1,22 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import subprocess
 import sys
 
 if len(sys.argv) != 4:
-    print "Usage: sshrecon.py <ip address> <port> <log directory>"
+    print("Usage: sshrecon.py <ip address> <port> <log directory>")
     sys.exit(0)
 
 ip_address = sys.argv[1].strip()
 port = sys.argv[2].strip()
 log_dir = sys.argv[3].strip()
 
-print "INFO: Performing hydra ssh scan against " + ip_address 
+print("INFO: Performing hydra ssh scan against " + ip_address)
 HYDRA = "hydra -L wordlists/userlist -P wordlists/offsecpass -f -o %s/%s/%s_sshhydra.txt -u %s -s %s ssh" % (log_dir, ip_address, ip_address, ip_address, port)
 try:
-    results = subprocess.check_output(HYDRA, shell=True)
+    results = subprocess.check_output(HYDRA, shell=True).decode('utf-8')
     resultarr = results.split("\n")
     for result in resultarr:
         if "login:" in result:
-	    print "[*] Valid ssh credentials found: " + result 
+            print("[*] Valid ssh credentials found: " + result)
 except:
-    print "INFO: No valid ssh credentials found"
+    print("INFO: No valid ssh credentials found")


### PR DESCRIPTION
## Summary

Fully upgrades `reconscan.py`, `dirbust.py`, and `sshrecon.py` from Python 2 to Python 3, and modernizes the code with idiomatic Python 3 patterns.

### Python 2 → 3 compatibility
- Update shebangs to `python3`
- Convert all `print` statements to `print()` functions
- Decode `subprocess.check_output()` results with `.decode('utf-8')`
- Update `socket.send()` calls to use bytes literals (`b"..."`)
- Decode `socket.recv()` output with `.decode('utf-8', errors='replace')`
- Add raw string prefix (`r'...'`) to regex patterns
- Fix mixed tabs/spaces indentation in `dirbust.py` (TabError in Python 3)
- Move module-level code inside `if __name__ == '__main__'` guard to prevent child processes from exiting prematurely (macOS uses `spawn` instead of `fork` for multiprocessing in Python 3)
- Fix `hydra` command syntax in `sshrecon.py` to use modern `ssh://host:port` format

### Pythonic modernization
- Replace all `%` string formatting with f-strings
- Replace `subprocess.check_output().decode()` with `subprocess.run(capture_output=True, text=True)`
- Extract `run()` helper in `reconscan.py` to reduce subprocess boilerplate
- Replace `open/read/close` pairs with `pathlib` `Path.read_text()` / `Path.write_text()`
- Replace chained `if` statements for placeholder lookup with a dictionary
- Replace socket manual close with `with` context manager
- Replace subprocess `mkdir`/`cp`/`sed` calls with `os.makedirs()`, `shutil.copy()`, and `Path` operations
- Simplify `multProc` by removing unused `jobs` list
- Replace `while` loop whitespace normalization with `re.sub()`
- Use `.items()` in service dispatch loop and `setdefault()` for dict population
- Use `sys.argv[1:]` instead of `pop(0)`
- Replace bare `except:` with `except subprocess.CalledProcessError:`
- Replace `try/except` for empty list check with `if/else`
- Use `results.splitlines()` instead of `split("\n")`

## Test plan

- [x] `python3 -m py_compile` passes on all three scripts
- [x] `reconscan.py` runs successfully against Metasploitable 2 (`192.168.57.4`)
- [x] `dirbust.py` runs successfully against Metasploitable 2, discovering `/phpMyAdmin/`, `/phpinfo.php/`, `/dav/`, and more
- [x] `sshrecon.py` runs successfully against Metasploitable 2, finding valid credentials `msfadmin:msfadmin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)